### PR TITLE
fix build for openjdk 11.05

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,9 @@ apply plugin: 'base'
 apply plugin: 'application'
 apply plugin: 'eclipse'
 apply plugin: 'jacoco'
+jacoco {
+	 toolVersion = "0.8.2"
+}
 
 mainClassName = 'org.opt4j.core.start.Opt4J'
 
@@ -64,6 +67,9 @@ subprojects {
     apply plugin: 'signing'
     apply plugin: 'eclipse'
     apply plugin: 'jacoco'
+	jacoco {
+		toolVersion = "0.8.2"
+	}
 
     sourceCompatibility = 1.8 
 	targetCompatibility = 1.8


### PR DESCRIPTION
with openjdk 11.05 (i.e. computer science cip pool machines)  the build fails with a lengthy error message, see
[error.log](https://github.com/BossSeminarFAU/opt4j/files/3821115/error.log)
